### PR TITLE
Add client-side head tags for analytics

### DIFF
--- a/src/app/[locale]/diablo4/page.tsx
+++ b/src/app/[locale]/diablo4/page.tsx
@@ -4,6 +4,9 @@ import Link from "next/link";
 import Image from "next/image";
 import AdContainer from "@/components/ui/AdContainer";
 import { useParams } from "next/navigation";
+import Head from 'next/head';
+
+
 
 
 export default function Diablo4Page() {
@@ -11,7 +14,12 @@ export default function Diablo4Page() {
     const locale = (params.locale as string) || "ko";
 
     return (
-        <div>
+        <>
+            <Head>
+                <title>디아블로4 가이드 | KakiGaming</title>
+                <meta name="description" content="디아블로4 정보와 룬 시세 검색 기능을 제공합니다." />
+            </Head>
+            <div>
             <div className="relative h-64 mb-6 rounded-lg overflow-hidden">
                 <Image src="/images/diablo4-banner.jpg" alt="디아블로4" fill style={{ objectFit: "cover" }} sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw" />
                 <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
@@ -66,5 +74,6 @@ export default function Diablo4Page() {
                 </div>
             </div>
         </div>
+        </>
     );
 }

--- a/src/app/[locale]/diablo4/rune-price/page.tsx
+++ b/src/app/[locale]/diablo4/rune-price/page.tsx
@@ -4,11 +4,19 @@
 
 import RunePriceSearch from "@/components/calculators/RunePriceSearch";
 import { useTranslations } from 'next-intl';
+import Head from 'next/head';
+
+
 
 export default function RunePricePage() {
     const t = useTranslations('common');
-    
+
     return (
+        <>
+            <Head>
+                <title>디아블로4 룬 시세 검색 | KakiGaming</title>
+                <meta name="description" content="디아블로4 룬 가격을 실시간으로 확인할 수 있는 검색 도구입니다." />
+            </Head>
         <div>
             <h1 className="text-3xl font-bold mb-6">{t('diablo4.rune_price.title')}</h1>
             <p className="mb-6">{t('diablo4.rune_price.description')}</p>
@@ -25,5 +33,6 @@ export default function RunePricePage() {
 
             <RunePriceSearch />
         </div>
+        </>
     );
 }

--- a/src/app/[locale]/eldenring/nightlord/page.tsx
+++ b/src/app/[locale]/eldenring/nightlord/page.tsx
@@ -3,11 +3,19 @@
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import AdContainer from "@/components/ui/AdContainer";
+import Head from 'next/head';
+
+
 
 export default function EldenringNightlord() {
     const t = useTranslations("common");
 
     return (
+        <>
+        <Head>
+            <title>밤의 통치자 초보자 가이드 - 엘든링 | KakiGaming</title>
+            <meta name="description" content="엘든링 밤의 통치자를 처음 플레이하는 유저를 위한 단계별 가이드입니다." />
+        </Head>
         <div className="space-y-8">
             {/* 히어로 섹션 */}
             <div className="bg-gradient-to-r from-amber-800 to-gray-900 text-white rounded-lg p-8 mb-8 shadow-lg">
@@ -453,5 +461,6 @@ export default function EldenringNightlord() {
             {/* 광고 배너 */}
             <AdContainer size="horizontal" className="mb-8" />
         </div>
+        </>
     );
 }

--- a/src/app/[locale]/eldenring/page.tsx
+++ b/src/app/[locale]/eldenring/page.tsx
@@ -4,6 +4,9 @@ import { useTranslations } from "next-intl";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import AdContainer from "@/components/ui/AdContainer";
+import Head from 'next/head';
+
+
 
 export default function EldenringPage() {
     const t = useTranslations("common");
@@ -11,6 +14,11 @@ export default function EldenringPage() {
     const locale = (params.locale as string) || "ko";
 
     return (
+        <>
+        <Head>
+            <title>엘든링: 밤의 통치자 가이드 | KakiGaming</title>
+            <meta name="description" content="엘든링 스핀오프 작품 밤의 통치자에 대한 정보를 제공합니다." />
+        </Head>
         <div className="space-y-8">
             {/* 히어로 섹션 */}
             <div className="bg-gradient-to-r from-amber-800 to-gray-900 text-white rounded-lg p-8 mb-8 shadow-lg">
@@ -36,5 +44,6 @@ export default function EldenringPage() {
             {/* 광고 배너 */}
             <AdContainer size="horizontal" className="mb-8" />
         </div>
+        </>
     );
 }

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -5,6 +5,9 @@ import GameCard from "@/components/ui/GameCard";
 import AdContainer from "@/components/ui/AdContainer";
 import { useTranslations } from 'next-intl';
 import { usePathname, useParams } from 'next/navigation';
+import Head from 'next/head';
+
+
 
 // 클라이언트 컴포넌트
 export default function Home() {
@@ -12,8 +15,13 @@ export default function Home() {
     const pathname = usePathname();
     const params = useParams();
     const locale = params.locale as string || pathname.split('/')[1] || 'ko';
-    
+
     return (
+        <>
+            <Head>
+                <title>KakiGaming - 게임 가이드 &amp; 계산기</title>
+                <meta name="description" content="디아블로4, 토치라이트 등 다양한 게임의 공략과 계산기를 제공합니다." />
+            </Head>
         <div>
             {/* 히어로 섹션 */}
             <div className="bg-gradient-to-r from-purple-700 to-indigo-800 text-white rounded-lg p-8 mb-8 shadow-lg">
@@ -147,5 +155,6 @@ export default function Home() {
                 `
             }} />
         </div>
+        </>
     );
 }

--- a/src/app/[locale]/poe1/page.tsx
+++ b/src/app/[locale]/poe1/page.tsx
@@ -4,6 +4,9 @@ import { useTranslations } from 'next-intl';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import AdContainer from '@/components/ui/AdContainer';
+import Head from 'next/head';
+
+
 
 export default function PoePage() {
     const t = useTranslations('common');
@@ -11,6 +14,11 @@ export default function PoePage() {
     const locale = params.locale as string || 'ko';
 
     return (
+        <>
+            <Head>
+                <title>패스 오브 엑자일 가이드 | KakiGaming</title>
+                <meta name="description" content="패스 오브 엑자일 관련 가이드와 유용한 링크를 제공합니다." />
+            </Head>
         <div className="space-y-8">
             {/* 히어로 섹션 */}
             <div className="bg-gradient-to-r from-blue-800 to-gray-900 text-white rounded-lg p-8 mb-8 shadow-lg">
@@ -33,5 +41,6 @@ export default function PoePage() {
             {/* 광고 배너 */}
             <AdContainer size="horizontal" className="mb-8" />
         </div>
+        </>
     );
 }

--- a/src/app/[locale]/poe1/quicklinks/page.tsx
+++ b/src/app/[locale]/poe1/quicklinks/page.tsx
@@ -4,6 +4,9 @@ import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 import AdContainer from '@/components/ui/AdContainer';
 import { useState } from 'react';
+import Head from 'next/head';
+
+
 
 // 퀵 링크 아이템 타입 정의
 interface QuickLinkItem {
@@ -17,7 +20,7 @@ interface QuickLinkItem {
 
 export default function PoeQuickLinks() {
   const t = useTranslations('common.poe');
-  
+
   // 카테고리 필터링을 위한 상태
   const [activeCategory, setActiveCategory] = useState<string>('all');
   
@@ -217,6 +220,11 @@ export default function PoeQuickLinks() {
     : quickLinks.filter(link => link.category === activeCategory);
 
   return (
+    <>
+      <Head>
+        <title>패스 오브 엑자일 퀵 링크 모음 | KakiGaming</title>
+        <meta name="description" content="유용한 PoE 관련 사이트와 도구 링크를 한곳에 모았습니다." />
+      </Head>
     <div className="space-y-8">
       {/* 히어로 섹션 */}
       <div className="bg-gradient-to-r from-blue-800 to-gray-900 text-white rounded-lg p-8 mb-8 shadow-lg">
@@ -289,5 +297,6 @@ export default function PoeQuickLinks() {
       </div> */}
 
     </div>
+    </>
   );
 }

--- a/src/app/[locale]/torchlight/cooltime-calculator/page.tsx
+++ b/src/app/[locale]/torchlight/cooltime-calculator/page.tsx
@@ -4,6 +4,9 @@ import React, { useState } from "react";
 import { calcCoolTime, calcRequiredCool } from "@/app/utils/cooltimeUtils";
 import { InputBlock, ReadOnlyBlock } from "@/components/calculators/CooltimeBlocks";
 import styles from "@/components/calculators/CooltimeBlocks.module.css";
+import Head from 'next/head';
+
+
 
 export default function CooltimeCalculatorPage() {
     const [myCool, setMyCool] = useState(0);
@@ -33,6 +36,11 @@ export default function CooltimeCalculatorPage() {
     });
 
     return (
+        <>
+            <Head>
+                <title>쿨타임 계산기 - 토치라이트 인피니트 | KakiGaming</title>
+                <meta name="description" content="스킬 쿨타임을 계산해 최적의 토치라이트 인피니트 세팅을 찾아보세요." />
+            </Head>
         <div className={`${styles.calculator} ${styles.darkMode}`}>
             <h2 className={styles.title}>토치라이트 인피니트 쿨타임 계산기</h2>
 
@@ -95,5 +103,6 @@ export default function CooltimeCalculatorPage() {
                 클라이언트 적용을 위해 0.034초로 약간의 여유를 두는 것이 안전합니다.
             </div>
         </div>
+        </>
     );
 }

--- a/src/app/[locale]/torchlight/page.tsx
+++ b/src/app/[locale]/torchlight/page.tsx
@@ -7,6 +7,9 @@ import Image from "next/image";
 import AdContainer from "@/components/ui/AdContainer";
 import { useTranslations } from "next-intl";
 import { useParams } from "next/navigation";
+import Head from 'next/head';
+
+
 
 export default function TorchlightPage() {
     const t = useTranslations("common");
@@ -14,6 +17,11 @@ export default function TorchlightPage() {
     const locale = (params.locale as string) || "ko";
 
     return (
+        <>
+            <Head>
+                <title>토치라이트 인피니트 가이드 | KakiGaming</title>
+                <meta name="description" content="토치라이트 인피니트의 공략과 계산기 정보를 제공합니다." />
+            </Head>
         <div>
             <div className="relative h-64 mb-6 rounded-lg overflow-hidden">
                 <Image src="/images/torchlight-banner.jpg" alt={t("torchlight.title")} fill style={{ objectFit: "cover" }} sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw" />
@@ -61,5 +69,6 @@ export default function TorchlightPage() {
                 </div>
             </div>
         </div>
+        </>
     );
 }


### PR DESCRIPTION
## Summary
- fix crash by removing Next.js metadata exports
- add `<Head>` elements for titles and descriptions on all game pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pnpm lint` *(fails: `next` not found, node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_68454c3d91b4832498ebf263453b004f