### PR TITLE
Update calculators to light theme

### DIFF
--- a/src/components/calculators/CooltimeBlocks.module.css
+++ b/src/components/calculators/CooltimeBlocks.module.css
@@ -2,20 +2,20 @@
     font-family: "Noto Sans KR", sans-serif;
     max-width: 100%;
     margin: 0 auto;
-    color: #f5f5f5;
-    background-color: #1e1e1e;
+    color: #000;
+    background-color: #fff;
     border-radius: 8px;
     padding: 20px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
 .darkMode {
-    color: #f5f5f5;
-    background-color: #1e1e1e;
+    color: #000;
+    background-color: #fff;
 }
 
 .title {
-    color: #f5f5f5;
+    color: #000;
     font-size: 1.5rem;
     font-weight: 700;
     margin-bottom: 20px;
@@ -23,7 +23,7 @@
 }
 
 .sectionTitle {
-    color: #f5f5f5;
+    color: #000;
     font-size: 1.2rem;
     font-weight: 600;
     margin: 20px 0 15px 0;
@@ -32,7 +32,7 @@
 }
 
 .globalSettings {
-    background-color: #2a2a2a;
+    background-color: #f5f5f5;
     border-radius: 8px;
     padding: 15px;
     margin-bottom: 20px;
@@ -47,7 +47,7 @@
     margin-bottom: 8px;
     font-size: 1.2rem;
     font-weight: 500;
-    color: #f5f5f5;
+    color: #000;
 }
 
 .formControl {
@@ -55,8 +55,8 @@
     padding: 10px;
     border: 1px solid #444;
     border-radius: 4px;
-    background-color: #333;
-    color: #f5f5f5;
+    background-color: #fff;
+    color: #000;
     font-size: 1rem;
 }
 
@@ -77,7 +77,7 @@
 }
 
 .checkboxLabel {
-    color: #f5f5f5;
+    color: #000;
     cursor: pointer;
 }
 
@@ -89,7 +89,7 @@
 }
 
 .skillCard {
-    background-color: #2a2a2a;
+    background-color: #f5f5f5;
     border-radius: 8px;
     padding: 15px;
     border-left: 4px solid #3498db;
@@ -126,14 +126,14 @@
 
 .unitLabel {
     margin: 0 8px;
-    color: #f5f5f5;
+    color: #000;
 }
 
 .addButton,
 .removeButton {
     background-color: transparent;
     border: 1px solid #444;
-    color: #f5f5f5;
+    color: #000;
     padding: 5px 10px;
     border-radius: 4px;
     cursor: pointer;
@@ -209,14 +209,14 @@
 }
 
 .resultsContainer {
-    background-color: #2a2a2a;
+    background-color: #f5f5f5;
     border-radius: 8px;
     padding: 15px;
     margin-bottom: 20px;
 }
 
 .resultsTitle {
-    color: #f5f5f5;
+    color: #000;
     font-size: 1.2rem;
     font-weight: 600;
     margin-bottom: 15px;
@@ -258,7 +258,7 @@
 }
 
 .resultSubtitle {
-    color: #f5f5f5;
+    color: #000;
     font-size: 1.1rem;
     font-weight: 500;
     margin-bottom: 10px;
@@ -307,7 +307,7 @@
 }
 
 .calculationGuide {
-    background-color: #2a2a2a;
+    background-color: #f5f5f5;
     border-radius: 8px;
     padding: 15px;
 }
@@ -327,13 +327,13 @@
     border-radius: 4px;
     margin-bottom: 15px;
     font-family: monospace;
-    color: #f5f5f5;
+    color: #000;
     font-weight: 500;
     text-align: center;
 }
 
 .guideSubtitle {
-    color: #f5f5f5;
+    color: #000;
     font-size: 1.1rem;
     font-weight: 500;
     margin: 15px 0 10px 0;
@@ -346,7 +346,7 @@
 
 .calculationStep {
     margin-bottom: 8px;
-    color: #f5f5f5;
+    color: #000;
 }
 
 .guideList {
@@ -356,7 +356,7 @@
 
 .guideItem {
     margin-bottom: 8px;
-    color: #f5f5f5;
+    color: #000;
 }
 
 .warningBox {
@@ -364,7 +364,7 @@
     border-left: 4px solid #e74c3c;
     padding: 15px;
     border-radius: 4px;
-    color: #f5f5f5;
+    color: #000;
 }
 
 /* 모바일 최적화 */
@@ -418,8 +418,8 @@
     }
 
     .readOnlyInput {
-        background-color: #2a2a2a;
-        color: #f5f5f5;
+        background-color: #f5f5f5;
+        color: #000;
         border: 1px solid #444;
         border-radius: 4px;
         padding: 10px;

--- a/src/components/calculators/MPCalculator.module.css
+++ b/src/components/calculators/MPCalculator.module.css
@@ -2,20 +2,20 @@
   font-family: 'Noto Sans KR', sans-serif;
   max-width: 100%;
   margin: 0 auto;
-  color: #f5f5f5;
-  background-color: #1e1e1e;
+  color: #000;
+  background-color: #fff;
   border-radius: 8px;
   padding: 20px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
 .darkMode {
-  color: #f5f5f5;
-  background-color: #1e1e1e;
+  color: #000;
+  background-color: #fff;
 }
 
 .title {
-  color: #f5f5f5;
+  color: #000;
   font-size: 1.5rem;
   font-weight: 700;
   margin-bottom: 20px;
@@ -23,7 +23,7 @@
 }
 
 .sectionTitle {
-  color: #f5f5f5;
+  color: #000;
   font-size: 1.2rem;
   font-weight: 600;
   margin: 20px 0 15px 0;
@@ -32,7 +32,7 @@
 }
 
 .globalSettings {
-  background-color: #2a2a2a;
+  background-color: #f5f5f5;
   border-radius: 8px;
   padding: 15px;
   margin-bottom: 20px;
@@ -46,7 +46,7 @@
   display: block;
   margin-bottom: 8px;
   font-weight: 500;
-  color: #f5f5f5;
+  color: #000;
 }
 
 .formControl {
@@ -54,8 +54,8 @@
   padding: 10px;
   border: 1px solid #444;
   border-radius: 4px;
-  background-color: #333;
-  color: #f5f5f5;
+  background-color: #fff;
+  color: #000;
   font-size: 1rem;
 }
 
@@ -76,7 +76,7 @@
 }
 
 .checkboxLabel {
-  color: #f5f5f5;
+  color: #000;
   cursor: pointer;
 }
 
@@ -88,7 +88,7 @@
 }
 
 .skillCard {
-  background-color: #2a2a2a;
+  background-color: #f5f5f5;
   border-radius: 8px;
   padding: 15px;
   border-left: 4px solid #3498db;
@@ -125,13 +125,13 @@
 
 .unitLabel {
   margin: 0 8px;
-  color: #f5f5f5;
+  color: #000;
 }
 
 .addButton, .removeButton {
   background-color: transparent;
   border: 1px solid #444;
-  color: #f5f5f5;
+  color: #000;
   padding: 5px 10px;
   border-radius: 4px;
   cursor: pointer;
@@ -206,14 +206,14 @@
 }
 
 .resultsContainer {
-  background-color: #2a2a2a;
+  background-color: #f5f5f5;
   border-radius: 8px;
   padding: 15px;
   margin-bottom: 20px;
 }
 
 .resultsTitle {
-  color: #f5f5f5;
+  color: #000;
   font-size: 1.2rem;
   font-weight: 600;
   margin-bottom: 15px;
@@ -254,7 +254,7 @@
 }
 
 .resultSubtitle {
-  color: #f5f5f5;
+  color: #000;
   font-size: 1.1rem;
   font-weight: 500;
   margin-bottom: 10px;
@@ -302,7 +302,7 @@
 }
 
 .calculationGuide {
-  background-color: #2a2a2a;
+  background-color: #f5f5f5;
   border-radius: 8px;
   padding: 15px;
 }
@@ -322,13 +322,13 @@
   border-radius: 4px;
   margin-bottom: 15px;
   font-family: monospace;
-  color: #f5f5f5;
+  color: #000;
   font-weight: 500;
   text-align: center;
 }
 
 .guideSubtitle {
-  color: #f5f5f5;
+  color: #000;
   font-size: 1.1rem;
   font-weight: 500;
   margin: 15px 0 10px 0;
@@ -341,7 +341,7 @@
 
 .calculationStep {
   margin-bottom: 8px;
-  color: #f5f5f5;
+  color: #000;
 }
 
 .guideList {
@@ -351,7 +351,7 @@
 
 .guideItem {
   margin-bottom: 8px;
-  color: #f5f5f5;
+  color: #000;
 }
 
 .warningBox {
@@ -359,7 +359,7 @@
   border-left: 4px solid #e74c3c;
   padding: 15px;
   border-radius: 4px;
-  color: #f5f5f5;
+  color: #000;
 }
 
 /* 모바일 최적화 */

--- a/src/components/calculators/MysticCalculator.module.css
+++ b/src/components/calculators/MysticCalculator.module.css
@@ -2,20 +2,20 @@
   font-family: 'Noto Sans KR', sans-serif;
   max-width: 100%;
   margin: 0 auto;
-  color: #f5f5f5;
-  background-color: #1e1e1e;
+  color: #000;
+  background-color: #fff;
   border-radius: 8px;
   padding: 20px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
 .darkMode {
-  color: #f5f5f5;
-  background-color: #1e1e1e;
+  color: #000;
+  background-color: #fff;
 }
 
 .title {
-  color: #f5f5f5;
+  color: #000;
   font-size: 1.5rem;
   font-weight: 700;
   margin-bottom: 20px;
@@ -23,7 +23,7 @@
 }
 
 .sectionTitle {
-  color: #f5f5f5;
+  color: #000;
   font-size: 1.2rem;
   font-weight: 600;
   margin: 20px 0 15px 0;
@@ -32,7 +32,7 @@
 }
 
 .globalSettings {
-  background-color: #2a2a2a;
+  background-color: #f5f5f5;
   border-radius: 8px;
   padding: 15px;
   margin-bottom: 20px;
@@ -46,7 +46,7 @@
   display: block;
   margin-bottom: 8px;
   font-weight: 500;
-  color: #f5f5f5;
+  color: #000;
 }
 
 .formControl {
@@ -54,8 +54,8 @@
   padding: 10px;
   border: 1px solid #444;
   border-radius: 4px;
-  background-color: #333;
-  color: #f5f5f5;
+  background-color: #fff;
+  color: #000;
   font-size: 1rem;
 }
 
@@ -76,7 +76,7 @@
 }
 
 .checkboxLabel {
-  color: #f5f5f5;
+  color: #000;
   cursor: pointer;
 }
 
@@ -88,7 +88,7 @@
 }
 
 .skillCard {
-  background-color: #2a2a2a;
+  background-color: #f5f5f5;
   border-radius: 8px;
   padding: 15px;
   border-left: 4px solid #3498db;
@@ -125,13 +125,13 @@
 
 .unitLabel {
   margin: 0 8px;
-  color: #f5f5f5;
+  color: #000;
 }
 
 .addButton, .removeButton {
   background-color: transparent;
   border: 1px solid #444;
-  color: #f5f5f5;
+  color: #000;
   padding: 5px 10px;
   border-radius: 4px;
   cursor: pointer;
@@ -206,14 +206,14 @@
 }
 
 .resultsContainer {
-  background-color: #2a2a2a;
+  background-color: #f5f5f5;
   border-radius: 8px;
   padding: 15px;
   margin-bottom: 20px;
 }
 
 .resultsTitle {
-  color: #f5f5f5;
+  color: #000;
   font-size: 1.2rem;
   font-weight: 600;
   margin-bottom: 15px;
@@ -254,7 +254,7 @@
 }
 
 .resultSubtitle {
-  color: #f5f5f5;
+  color: #000;
   font-size: 1.1rem;
   font-weight: 500;
   margin-bottom: 10px;
@@ -302,7 +302,7 @@
 }
 
 .calculationGuide {
-  background-color: #2a2a2a;
+  background-color: #f5f5f5;
   border-radius: 8px;
   padding: 15px;
 }
@@ -322,13 +322,13 @@
   border-radius: 4px;
   margin-bottom: 15px;
   font-family: monospace;
-  color: #f5f5f5;
+  color: #000;
   font-weight: 500;
   text-align: center;
 }
 
 .guideSubtitle {
-  color: #f5f5f5;
+  color: #000;
   font-size: 1.1rem;
   font-weight: 500;
   margin: 15px 0 10px 0;
@@ -341,7 +341,7 @@
 
 .calculationStep {
   margin-bottom: 8px;
-  color: #f5f5f5;
+  color: #000;
 }
 
 .guideList {
@@ -351,7 +351,7 @@
 
 .guideItem {
   margin-bottom: 8px;
-  color: #f5f5f5;
+  color: #000;
 }
 
 .warningBox {
@@ -359,7 +359,7 @@
   border-left: 4px solid #e74c3c;
   padding: 15px;
   border-radius: 4px;
-  color: #f5f5f5;
+  color: #000;
 }
 
 /* 모바일 최적화 */

--- a/src/components/calculators/PenetrationCalculator.module.css
+++ b/src/components/calculators/PenetrationCalculator.module.css
@@ -2,20 +2,20 @@
   font-family: 'Noto Sans KR', sans-serif;
   max-width: 100%;
   margin: 0 auto;
-  color: #f5f5f5;
-  background-color: #1e1e1e;
+  color: #000;
+  background-color: #fff;
   border-radius: 8px;
   padding: 20px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
 .darkMode {
-  color: #f5f5f5;
-  background-color: #1e1e1e;
+  color: #000;
+  background-color: #fff;
 }
 
 .title {
-  color: #f5f5f5;
+  color: #000;
   font-size: 1.5rem;
   font-weight: 700;
   margin-bottom: 20px;
@@ -23,7 +23,7 @@
 }
 
 .sectionTitle {
-  color: #f5f5f5;
+  color: #000;
   font-size: 1.2rem;
   font-weight: 600;
   margin: 20px 0 15px 0;
@@ -32,7 +32,7 @@
 }
 
 .globalSettings {
-  background-color: #2a2a2a;
+  background-color: #f5f5f5;
   border-radius: 8px;
   padding: 15px;
   margin-bottom: 20px;
@@ -46,7 +46,7 @@
   display: block;
   margin-bottom: 8px;
   font-weight: 500;
-  color: #f5f5f5;
+  color: #000;
 }
 
 .formControl {
@@ -54,8 +54,8 @@
   padding: 10px;
   border: 1px solid #444;
   border-radius: 4px;
-  background-color: #333;
-  color: #f5f5f5;
+  background-color: #fff;
+  color: #000;
   font-size: 1rem;
 }
 
@@ -76,7 +76,7 @@
 }
 
 .checkboxLabel {
-  color: #f5f5f5;
+  color: #000;
   cursor: pointer;
 }
 
@@ -88,7 +88,7 @@
 }
 
 .skillCard {
-  background-color: #2a2a2a;
+  background-color: #f5f5f5;
   border-radius: 8px;
   padding: 15px;
   border-left: 4px solid #3498db;
@@ -125,13 +125,13 @@
 
 .unitLabel {
   margin: 0 8px;
-  color: #f5f5f5;
+  color: #000;
 }
 
 .addButton, .removeButton {
   background-color: transparent;
   border: 1px solid #444;
-  color: #f5f5f5;
+  color: #000;
   padding: 5px 10px;
   border-radius: 4px;
   cursor: pointer;
@@ -206,14 +206,14 @@
 }
 
 .resultsContainer {
-  background-color: #2a2a2a;
+  background-color: #f5f5f5;
   border-radius: 8px;
   padding: 15px;
   margin-bottom: 20px;
 }
 
 .resultsTitle {
-  color: #f5f5f5;
+  color: #000;
   font-size: 1.2rem;
   font-weight: 600;
   margin-bottom: 15px;
@@ -254,7 +254,7 @@
 }
 
 .resultSubtitle {
-  color: #f5f5f5;
+  color: #000;
   font-size: 1.1rem;
   font-weight: 500;
   margin-bottom: 10px;
@@ -302,7 +302,7 @@
 }
 
 .calculationGuide {
-  background-color: #2a2a2a;
+  background-color: #f5f5f5;
   border-radius: 8px;
   padding: 15px;
 }
@@ -322,13 +322,13 @@
   border-radius: 4px;
   margin-bottom: 15px;
   font-family: monospace;
-  color: #f5f5f5;
+  color: #000;
   font-weight: 500;
   text-align: center;
 }
 
 .guideSubtitle {
-  color: #f5f5f5;
+  color: #000;
   font-size: 1.1rem;
   font-weight: 500;
   margin: 15px 0 10px 0;
@@ -341,7 +341,7 @@
 
 .calculationStep {
   margin-bottom: 8px;
-  color: #f5f5f5;
+  color: #000;
 }
 
 .guideList {
@@ -351,7 +351,7 @@
 
 .guideItem {
   margin-bottom: 8px;
-  color: #f5f5f5;
+  color: #000;
 }
 
 .warningBox {
@@ -359,7 +359,7 @@
   border-left: 4px solid #e74c3c;
   padding: 15px;
   border-radius: 4px;
-  color: #f5f5f5;
+  color: #000;
 }
 
 /* 모바일 최적화 */


### PR DESCRIPTION
🚫 규칙 제외

## Summary
- adjust background and text colors in calculator modules to use white backgrounds and black text

## Testing
- `git diff --stat`

------
https://chatgpt.com/codex/tasks/task_e_688c6e07a02483248562307e59d3af99